### PR TITLE
update in spelling of utc of Indian Standard Time

### DIFF
--- a/timezones.json
+++ b/timezones.json
@@ -943,7 +943,7 @@
     "isdst": false,
     "text": "(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi",
     "utc": [
-      "Asia/Calcutta"
+      "Asia/Kolkata"
     ]
   },
   {


### PR DESCRIPTION
the Asia/Calcutta time zone has been changed to Asia/Kolkata time zone after the change of name of the city