### PR TITLE
Add missing "utc" fields

### DIFF
--- a/timezones.json
+++ b/timezones.json
@@ -442,7 +442,8 @@
     "abbr": "MDT",
     "offset": -1,
     "isdst": true,
-    "text": "(UTC-02:00) Mid-Atlantic - Old"
+    "text": "(UTC-02:00) Mid-Atlantic - Old",
+    "utc": []
   },
   {
     "value": "Azores Standard Time",
@@ -680,7 +681,24 @@
     "abbr": "EEDT",
     "offset": 3,
     "isdst": true,
-    "text": "(UTC+02:00) E. Europe"
+    "text": "(UTC+02:00) E. Europe",
+    "utc": [
+      "Asia/Nicosia",
+      "Europe/Athens",
+      "Europe/Bucharest",
+      "Europe/Chisinau",
+      "Europe/Helsinki",
+      "Europe/Kiev",
+      "Europe/Mariehamn",
+      "Europe/Nicosia",
+      "Europe/Riga",
+      "Europe/Sofia",
+      "Europe/Tallinn",
+      "Europe/Uzhgorod",
+      "Europe/Vilnius",
+      "Europe/Zaporozhye"
+
+    ]
   },
   {
     "value": "South Africa Standard Time",


### PR DESCRIPTION
Fixes #12.

I couldn't find very much information on the Mid-Atlantic timezone. Based on [this](https://blogs.technet.microsoft.com/dst2007/2013/12/09/december-2013-dst-cumulative-update-for-windows-operating-systems/), Windows deprecated it, so I assume it's included here for backwards-compatibility.

The data for the E. Europe timezone is based on [this](https://en.wikipedia.org/wiki/Eastern_European_Time).