### PR TITLE
renamed `Greenwich Mean Time` to `GMT Standard Time`

### DIFF
--- a/timezones.json
+++ b/timezones.json
@@ -504,7 +504,7 @@
     ]
   },
   {
-    "value": "Greenwich Mean Time",
+    "value": "GMT Standard Time",
     "abbr": "GMT",
     "offset": 0,
     "isdst": false,


### PR DESCRIPTION
Operating system do not use `Greenwich Mean Time`. They use `GMT Standard Time` specially windows OS. https://support.microsoft.com/en-us/help/973627/microsoft-time-zone-index-values. This is causing application to break-down completely in various other operating systems as well. Hence renaming to mostly used name