### PR TITLE
Add America/Argentina/X (formerly America/X) timezones

### DIFF
--- a/timezones.json
+++ b/timezones.json
@@ -397,7 +397,12 @@
     "isdst": false,
     "text": "(UTC-03:00) Buenos Aires",
     "utc": [
+      "America/Argentina/Buenos_Aires",
+      "America/Argentina/Catamarca",
+      "America/Argentina/Cordoba",
+      "America/Argentina/Jujuy",
       "America/Argentina/La_Rioja",
+      "America/Argentina/Mendoza",
       "America/Argentina/Rio_Gallegos",
       "America/Argentina/Salta",
       "America/Argentina/San_Juan",


### PR DESCRIPTION
Buenos Aires has a number of `America/X` timezones that are obsolete and should be replaced by  `America/Argentina/X` timezones, e.g. `America/Argentina/Buenos_Aires` instead of `America/Buenos_Aires`.

- http://www.timezoneconverter.com/cgi-bin/zoneinfo.tzc?s=default&tz=America/Buenos_Aires
- http://www.timezoneconverter.com/cgi-bin/zoneinfo.tzc?s=default&tz=America/Catamarca
- http://www.timezoneconverter.com/cgi-bin/zoneinfo.tzc?s=default&tz=America/Cordoba
- http://www.timezoneconverter.com/cgi-bin/zoneinfo.tzc?s=default&tz=America/Jujuy
- http://www.timezoneconverter.com/cgi-bin/zoneinfo.tzc?s=default&tz=America/Mendoza

This PR adds the new timezones. It keeps the existing ones for backwards compatibility.