### PR TITLE
changed Kiev to Kyiv

### DIFF
--- a/timezones.json
+++ b/timezones.json
@@ -751,7 +751,7 @@
       "Europe/Bucharest",
       "Europe/Chisinau",
       "Europe/Helsinki",
-      "Europe/Kiev",
+      "Europe/Kyiv",
       "Europe/Mariehamn",
       "Europe/Nicosia",
       "Europe/Riga",
@@ -792,7 +792,7 @@
     "text": "(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius",
     "utc": [
       "Europe/Helsinki",
-      "Europe/Kiev",
+      "Europe/Kyiv",
       "Europe/Mariehamn",
       "Europe/Riga",
       "Europe/Sofia",


### PR DESCRIPTION
The names "Kiev" and "Kyiv" were used in the file, which is not very convenient. Better use only "Kyiv" because it's the right way to write it (source: [https://wondersholidays.com/ru/kak-pishetsya-kiev-angliyskiy/](url))